### PR TITLE
Add file uploads for ProbRA tasks

### DIFF
--- a/webserver/templates/task.html
+++ b/webserver/templates/task.html
@@ -103,9 +103,46 @@
       messagesContainer.scrollTop = messagesContainer.scrollHeight;
     }
 
+    function appendResultFile(file) {
+      const container = document.getElementById('results-tab');
+      const box = document.createElement('div');
+      box.className = 'result-box';
+
+      const header = document.createElement('div');
+      header.className = 'result-header';
+      header.textContent = file.filename;
+      box.appendChild(header);
+
+      const body = document.createElement('div');
+      body.className = 'result-body';
+
+      const url = file.s3_url || file.filepath;
+      const name = file.filename.toLowerCase();
+      if (/\.(png|jpg|jpeg|gif)$/.test(name)) {
+        const img = document.createElement('img');
+        img.src = url;
+        img.alt = file.filename;
+        img.className = 'result-image';
+        body.appendChild(img);
+      } else {
+        const link = document.createElement('a');
+        link.href = url;
+        link.textContent = 'Download ' + file.filename;
+        body.appendChild(link);
+      }
+
+      box.appendChild(body);
+      container.appendChild(box);
+    }
+
     socket.on("task_message", (data) => {
         console.log("task_message", data);
         appendMessage('assistant', data['content']);
+    });
+
+    socket.on("task_file", (data) => {
+        console.log("task_file", data);
+        appendResultFile(data);
     });
 
     socket.on("complete", (data) => {

--- a/workflows/probra.py
+++ b/workflows/probra.py
@@ -1,17 +1,53 @@
-import redis, json, time
+import redis
+import json
+import time
+import os
+import uuid
 from workflows.celery_worker import celery
 from webserver.model.message import MessageSchema
+from webserver import S3FileStorage
 
 @celery.task(bind=True)
 def probra_task(self, payload):
+    """Example background task that emits progress messages and uploads a file."""
     r = redis.Redis()
-    task_id = payload['task_id']
+    task_id = payload.get("task_id")
+    sid = payload.get("sid")
+    user_id = payload.get("user_id")
+
     for i in range(5):
         message = MessageSchema(role="assistant", content=f"Step {i}")
-        event = { "type": "task_message", "data": message.model_dump(), "task_id": task_id }
+        event = {
+            "type": "task_message",
+            "data": message.model_dump(),
+            "task_id": task_id,
+            "sid": sid,
+        }
         r.publish("celery_updates", json.dumps(event))
         time.sleep(1)
-    
-    result = {"task_id": task_id, "type": "task_file", "data": "{}"}
-    r.publish("celery_updates", json.dumps(result))
+
+    # ------------------------------------------------------------------
+    # Create a simple result file and upload it to S3
+    tmp_filename = f"probra_result_{uuid.uuid4().hex}.txt"
+    tmp_path = os.path.join("/tmp", tmp_filename)
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        f.write("ProbRA task complete.\n")
+
+    storage = S3FileStorage()
+    s3_key = storage.upload_file(tmp_path, f"{task_id}/{tmp_filename}", "text/plain")
+    download_url = storage.generate_download_url(s3_key)
+
+    file_event = {
+        "type": "task_file",
+        "task_id": task_id,
+        "sid": sid,
+        "data": {
+            "user_id": user_id,
+            "filename": tmp_filename,
+            "filepath": s3_key,
+            "s3_url": download_url,
+        },
+    }
+    r.publish("celery_updates", json.dumps(file_event))
+
     return {"done": True}


### PR DESCRIPTION
## Summary
- upload a result file to S3 from `probra_task`
- store and broadcast `task_file` events
- pass user id to celery tasks
- update listener and frontend to display uploaded files

## Testing
- `python -m py_compile workflows/probra.py webserver/app.py`