### PR TITLE
Refactor flake shellhook

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,112 +52,28 @@
           ];
 
           shellHook = ''
-            echo "Setting up PostgreSQL development environment..."
+            scripts/flake/setup_postgres.sh \
+              "${pgSettings.user}" \
+              "${pgSettings.password}" \
+              "${pgSettings.port}" \
+              "${pgSettings.dbName}" \
+              "${pgSettings.host}" \
+              "${pgSettings.socketDirSubPath}" \
+              "${pkgs.postgresql_15}/bin"
 
-            export PGDATA="$PWD/.postgres/data"
-            # Define and create the explicit socket directory for the server
-            export PG_SOCKET_DIR="$PWD/.postgres/${pgSettings.socketDirSubPath}"
-
-            export PGUSER="${pgSettings.user}"
-            export PGPASSWORD="${pgSettings.password}"
-            export PGHOST="${pgSettings.host}" # For clients to default to TCP/IP
-            export PGPORT="${pgSettings.port}"
-            export PGDATABASE="${pgSettings.dbName}"
-            export PATH="${pkgs.postgresql_15}/bin:$PATH"
-            
-            PGLOGFILE="$PWD/.postgres/logfile"
-
-            mkdir -p "$PWD/.postgres" # Ensure .postgres parent directory exists
-            mkdir -p "$PG_SOCKET_DIR"  # Ensure the socket directory exists before initdb/start
-
-            if [ ! -f "$PGDATA/postgresql.conf" ]; then
-              echo "Initializing new PostgreSQL instance in $PGDATA..."
-              mkdir -p "$PGDATA" # Ensure PGDATA directory itself exists
-              initdb --username="$PGUSER" --pwfile=<(echo "$PGPASSWORD") -D "$PGDATA"
-
-              echo "Configuring PostgreSQL..."
-              echo "listen_addresses = '${pgSettings.host}'" >> "$PGDATA/postgresql.conf"
-              echo "port = ${pgSettings.port}" >> "$PGDATA/postgresql.conf"
-              # Crucially, set a writable unix_socket_directories
-              echo "unix_socket_directories = '$PG_SOCKET_DIR'" >> "$PGDATA/postgresql.conf"
-            fi
-
-            if ! pg_ctl -D "$PGDATA" status > /dev/null 2>&1; then
-              echo "Starting PostgreSQL server (Log: $PGLOGFILE)..."
-              if ! pg_ctl -D "$PGDATA" -l "$PGLOGFILE" -w -t 30 start; then
-                echo "--------------------------------------------------------------------"
-                echo "PostgreSQL FAILED to start. Contents of $PGLOGFILE:"
-                cat "$PGLOGFILE"
-                echo "--------------------------------------------------------------------"
-                echo "Exiting due to PostgreSQL startup failure."
-                exit 1
-              fi
-              echo "PostgreSQL server started successfully."
-            else
-              echo "PostgreSQL already running."
-            fi
-
-            # Create database if it doesn't exist
-            # psql will use PGHOST=localhost and PGPORT for TCP/IP connection
-            if ! psql -lqt | cut -d \| -f 1 | grep -qw "${pgSettings.dbName}"; then
-              echo "Creating database: ${pgSettings.dbName}..."
-              createdb "${pgSettings.dbName}"
-            else
-              echo "Database ${pgSettings.dbName} already exists."
-            fi
-
-            # ... (AWS SSO Configuration - unchanged) ...
-             if [ -f .aws-profile ]; then
-              export AWS_PROFILE=$(cat .aws-profile)
-              echo "Using saved AWS_PROFILE=$AWS_PROFILE"
-            else
-              echo "No saved AWS_PROFILE found."
-              read -p "Enter your AWS SSO profile name: " entered_profile
-              export AWS_PROFILE=$entered_profile
-              echo "$AWS_PROFILE" > .aws-profile
-              echo "Saved AWS_PROFILE to .aws-profile"
-            fi
-
-            if ! grep -q "\[profile $AWS_PROFILE\]" ~/.aws/config 2>/dev/null; then
-              echo "AWS profile '$AWS_PROFILE' not found in ~/.aws/config. Launching 'aws configure sso'..."
-              aws configure sso
-            fi
-
-            echo "Triggering AWS SSO login for profile '$AWS_PROFILE'..."
-            if ! aws sts get-caller-identity --profile "$AWS_PROFILE" >/dev/null 2>&1; then
-              aws sso login --profile "$AWS_PROFILE"
-            fi
-
-            echo "Running Flyway migrations..."
-            flyway \
-              -url="jdbc:postgresql://${pgSettings.host}:${pgSettings.port}/${pgSettings.dbName}" \
-              -user="${pgSettings.user}" \
-              -password="${pgSettings.password}" \
-              -locations="filesystem:./flyway/sql" \
-              migrate
+            scripts/flake/aws_login.sh
+            scripts/flake/run_flyway.sh
+            scripts/flake/start_redis.sh
 
             echo "Loading application environment script..."
             bash scripts/load_environment.sh "$AWS_PROFILE" "insilica/toxindex+development"
 
-            echo "Starting Redis server..."
-            if ! pgrep redis-server > /dev/null; then
-              echo "Starting Redis server..."
-              redis-server --daemonize yes
-            else
-              echo "Redis is already running."
-            fi
-
-
             echo "Development environment ready."
-            echo "PostgreSQL is accessible on: ${pgSettings.host}:${pgSettings.port} (TCP/IP)"
-            echo "PostgreSQL server socket directory: $PG_SOCKET_DIR"
-            echo "Database: ${pgSettings.dbName}, User: ${pgSettings.user}"
-
             export FLASK_APP=webserver.app
             export FLASK_ENV=development
-            export DEBUG=1 
+            export DEBUG=1
             export PREFERRED_URL_SCHEME=http
-            export SERVER_NAME="${pgSettings.host}:6513" 
+            export SERVER_NAME="${pgSettings.host}:6513"
           '';
         };
 

--- a/scripts/flake/aws_login.sh
+++ b/scripts/flake/aws_login.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR/.."
+
+bash "$ROOT_DIR/shellhook_aws_login.sh"

--- a/scripts/flake/run_flyway.sh
+++ b/scripts/flake/run_flyway.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR/.."
+
+bash "$ROOT_DIR/shellhook_flyway.sh"

--- a/scripts/flake/setup_postgres.sh
+++ b/scripts/flake/setup_postgres.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Arguments:
+#   1 - PostgreSQL user
+#   2 - PostgreSQL password
+#   3 - PostgreSQL port
+#   4 - Database name
+#   5 - Host
+#   6 - Socket directory subpath
+#   7 - PostgreSQL bin path
+
+PG_SETTINGS_USER="$1"
+PG_SETTINGS_PASSWORD="$2"
+PG_SETTINGS_PORT="$3"
+PG_SETTINGS_DB_NAME="$4"
+PG_SETTINGS_HOST="$5"
+PG_SETTINGS_SOCKET_DIR_SUBPATH="$6"
+POSTGRESQL_BIN_PATH="$7"
+
+export PG_SETTINGS_USER PG_SETTINGS_PASSWORD PG_SETTINGS_PORT \
+       PG_SETTINGS_DB_NAME PG_SETTINGS_HOST PG_SETTINGS_SOCKET_DIR_SUBPATH \
+       POSTGRESQL_BIN_PATH
+
+# Call the existing PostgreSQL helper
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR/.."
+
+bash "$ROOT_DIR/shellhook_postgres.sh"

--- a/scripts/flake/start_redis.sh
+++ b/scripts/flake/start_redis.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! pgrep redis-server > /dev/null; then
+  echo "Starting Redis server..."
+  redis-server --daemonize yes
+else
+  echo "Redis is already running."
+fi


### PR DESCRIPTION
## Summary
- simplify `flake.nix` shellHook by calling small helper scripts
- add scripts for postgres setup, aws login, flyway migrations, and redis startup

## Testing
- `nix flake check` *(fails: `nix` not found)*